### PR TITLE
ファイル名やフォルダパス指定により変換が出来る様改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+temporary/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 ## Description
 
-カレントディレクトリ内の単一ページpdfをpngに一括変換するpythonスクリプトです．
+2通りの状況下で、pdfファイルをpng画像に変換するツールです。
+1. 単一ページpdfファイル一つをpng画像に変換する
+2. ディレクトリ内の単一ページpdfファイル(複数可)をpng画像に変換する
 
-`.pdf`部分が`.png`になったものがカレントディレクトリに出力されます．
+`.pdf`部分が`.png`になったものがpdfファイルと同じディレクトリに出力されます．
+
+複数ページpdfファイルを指定した場合、1ページ目のみがpng画像として出力されます。
 
 ## Requirements
 
@@ -20,29 +24,51 @@
     ```
 1. `convert_pdf-to-png.py`を好きな場所に保存
 
-2. 変換したいpdfファイルのあるディレクトリに移動
+2. 変換したいpdfファイルまたはフォルダを指定して`convert_pdf-to-png.py`を実行
+   - pdfファイル(単一ページ、単一ファイル)のパスを指定する場合
+     - `python3 convert_pdf-to-png.py <FULL filepath>`
+     - **フルパス** で指定しないと動作しないため注意 
+   - pdfファイル(単一ページ)のあるフォルダを指定する場合(フォルダ内に複数の単一ページpdfファイルがある場合も可)
+     - `python3 convert_pdf-to-png.py <FULL directorypath>`
+     - **フルパス** で指定しないと動作しないため注意 
+    
+例：以下のような構成の場合(カレントディレクトリは`/home/user/`を仮定)
 
-3. 移動したディレクトリ内で以下を実行
-    ```
-    $ python3 path/to/convert_pdf-to-png.py
-    ```
-    
-    例：以下のような構成の場合
-    
-    ```
-    ./
+```
+/home/user/
     ├── convert_pdf-to-png.py
     └── target_dir
         ├── a.pdf
         ├── b.pdf
         └── c.pdf
-    ```
+```
     
-    この場合，`target_dir`に移動して，その中からconvert_pdf-to-png.pyを実行する．
+### Example1
+
+    pdfファイル(a.pdfのみ)を指定してconvert_pdf-to-png.pyを実行する
     
     ```
-    $ cd target_dir
-    $ python3 ../convert_pdf-to-png.py
+    $ python3 ./convert_pdf-to-png.py /home/user/target_dir/a.pdf
+    ```
+
+    実行後は以下のようになる．
+
+    ```
+    ./
+    ├── convert_pdf-to-png.py
+    └── target_dir
+        ├── a.pdf
+        ├── a.png  <- a.pngが生成された
+        ├── b.pdf
+        └── c.pdf
+    ```
+
+### Example2
+
+    ディレクトリ(target_dir)を指定してconvert_pdf-to-png.pyを実行する
+    
+    ```
+    $ python3 ./convert_pdf-to-png.py /home/user/target_dir
     ```
 
     実行後は以下のようになる．

--- a/convert_pdf-to-png.py
+++ b/convert_pdf-to-png.py
@@ -1,33 +1,51 @@
-# カレントディレクトリ内のpdf -> pngに一括変換
-# 使用方法： 変換したいpdfのあるディレクトリにて「python3 <pdf2png.pyの相対パス>」を実行
+"""
+指定したディレクトリ内のpdf or 指定した単一ページPDFファイル一つをpngに一括変換
+usage：
+    $ python3 convert_pdf-to-png.py <FULL filepath>
+    $ python3 convert_pdf-to-png.py <FULL directorypath>
+"""
 
 from pdf2image import convert_from_path
 import sys
 import os
 
-# カレントディレクトリのフルパスを取得
-path_to_dir = os.getcwd()
-
-# 拡張子がpdfのファイル名を格納するリスト
-targets = []
-# カレントディレクトリ内で拡張子がpdfのものだけをtargetsに抽出
-for fileName in os.listdir(path_to_dir):
-    if ".pdf" in fileName:
-        # appendは，リストの末尾に要素を追加する
-        targets.append(fileName)
+# コマンドライン引数で指定されたパス
+path = sys.argv[1]
 
 # 変換予定のpdfファイルのフルパス格納用リスト
-path_to_targets = []
+pdfs_path = []
 # 変換後のpngファイルのフルパス指定用リスト
-converted_pdfs_path = []
+pngs_path = []
 
-# 変換するpdfファイルのフルパスのリストpath_to_targetsを作成
-for i in range(len(targets)):
-    temp_path = path_to_dir + '/' + targets[i]
-    path_to_targets.append(temp_path)
-    converted_pdfs_path.append(temp_path.replace('.pdf', '.png'))
+# コマンドライン引数がフォルダパスかファイルパスかを判定し、処理を分岐する
+if os.path.isdir(path):
+    # フォルダパスだった場合、フォルダ内全てのPDFファイルを変換対象とする
+    # カレントディレクトリ内で拡張子がpdfのものだけをpdfs_pathに抽出
+    for fileName in os.listdir(path):
+        if ".pdf" in fileName:
+            # 拡張子が.pdfのすべてのファイルのフルパスを生成して格納
+            temp_path = path + '/' + fileName
+            pdfs_path.append(temp_path)
+        if len(pdfs_path)==0:
+            print("ERROR : There is no PDF file!")
+            sys.exit(1)
+elif os.path.isfile(path):
+    # ファイルパスだった場合、指定されたPDFファイルを変換対象とする
+    # 一つでも拡張子が「.pdf」でないファイル名を指定すると、異常終了する
+    if not (".pdf" in path):
+        print("ERROR: You may have a wrong filename!")
+        sys.exit(1)
+    pdfs_path.append(path)
+else:
+    # ファイルでもディレクトリでもない場合、存在しない旨を表示し異常終了する
+    print("ERROR : Please input correct file or directory name.")
+    sys.exit(1)
 
-# path_to_targetsリストに記されたpdfファイルをpngに変換
-for i in range(len(targets)):
-    images = convert_from_path(path_to_targets[i])
-    images[0].save(converted_pdfs_path[i], 'png')
+# 変換するpdfファイルのフルパスのリストpdfs_pathを作成
+for i in range(len(pdfs_path)):
+    pngs_path.append(pdfs_path[i].replace('.pdf', '.png'))
+
+# pdfs_pathリストに記されたpdfファイルをpngに変換
+for i in range(len(pdfs_path)):
+    images = convert_from_path(pdfs_path[i])
+    images[0].save(pngs_path[i], 'png')


### PR DESCRIPTION
下記のようにファイルパスやディレクトリパスを指定して変換を行うよう変更を行った。

```
$ python3 convert_pdf-to-png.py <FULL filepath>
$ python3 convert_pdf-to-png.py <FULL directorypath>
```